### PR TITLE
Use `jupyter_server_documents`

### DIFF
--- a/packages/jupyterlab-chat-extension/package.json
+++ b/packages/jupyterlab-chat-extension/package.json
@@ -48,8 +48,8 @@
   },
   "dependencies": {
     "@jupyter-notebook/application": "^7.2.0",
-    "@jupyter/collaborative-drive": "^3.0.0",
-    "@jupyter/ydoc": "^2.0.0 || ^3.0.0",
+    "@jupyter/collaborative-drive": "^4.0.2",
+    "@jupyter/ydoc": "^2.1.3 || ^3.0.0",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.3.0",
     "@jupyterlab/coreutils": "^6.2.0",

--- a/packages/jupyterlab-chat-extension/package.json
+++ b/packages/jupyterlab-chat-extension/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@jupyter-notebook/application": "^7.2.0",
     "@jupyter/collaborative-drive": "^4.0.2",
-    "@jupyter/ydoc": "^2.1.3 || ^3.0.0",
+    "@jupyter/ydoc": "^3.0.0",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.3.0",
     "@jupyterlab/coreutils": "^6.2.0",

--- a/packages/jupyterlab-chat-extension/package.json
+++ b/packages/jupyterlab-chat-extension/package.json
@@ -58,7 +58,7 @@
     "@jupyterlab/launcher": "^4.2.0",
     "@jupyterlab/notebook": "^4.2.0",
     "@jupyterlab/rendermime": "^4.2.0",
-    "@jupyterlab/services": "^7.2.0",
+    "@jupyterlab/services": "^7.4.0",
     "@jupyterlab/settingregistry": "^4.2.0",
     "@jupyterlab/translation": "^4.2.0",
     "@jupyterlab/ui-components": "^4.2.0",

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -21,7 +21,6 @@ import {
   readIcon
 } from '@jupyter/chat';
 import { ICollaborativeContentProvider } from '@jupyter/collaborative-drive';
-import { SharedDocumentFactory } from '@jupyterlab/services';
 import {
   ILayoutRestorer,
   JupyterFrontEnd,
@@ -47,7 +46,7 @@ import { Contents } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { launchIcon } from '@jupyterlab/ui-components';
-import { PromiseDelegate } from '@lumino/coreutils';
+import { PromiseDelegate, Token } from '@lumino/coreutils';
 import {
   ChatPanel,
   ChatWidgetFactory,
@@ -67,8 +66,16 @@ import {
 import { chatCommandRegistryPlugin } from './chat-commands/plugins';
 import { emojiCommandsPlugin } from './chat-commands/providers/emoji';
 import { mentionCommandsPlugin } from './chat-commands/providers/user-mention';
+import { DocumentChange, YDocument } from '@jupyter/ydoc';
 
 const FACTORY = 'Chat';
+
+// Cast ICollaborativeContentProvider token to Token<any> for JupyterLab compatibility.
+// Safe because different @lumino/coreutils versions create separate Token types with
+// private '_tokenStructuralPropertyT' properties. Tokens are just dependency injection
+// identifiers, the actual ICollaborativeContentProvider instance works correctly.
+const ICollaborativeContentProviderToken =
+  ICollaborativeContentProvider as unknown as Token<any>;
 
 const pluginIds = {
   activeCellManager: 'jupyterlab-chat-extension:activeCellManager',
@@ -111,7 +118,7 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
     IActiveCellManagerToken,
     IAttachmentOpenerRegistry,
     IChatCommandRegistry,
-    ICollaborativeContentProvider,
+    ICollaborativeContentProviderToken,
     IDefaultFileBrowser,
     IInputToolbarRegistryFactory,
     ILayoutRestorer,
@@ -265,8 +272,12 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
     app.docRegistry.addFileType(chatFileType);
 
     if (drive) {
-      const chatFactory: SharedDocumentFactory = () => {
-        return YChat.create();
+      // Cast YChat (YDocument<IChatChanges>) to YDocument<DocumentChange> for SharedDocumentFactory.
+      // Safe because IChatChanges extends DocumentChange, so YChat has all required functionality.
+      // TypeScript's generic invariance prevents YDocument<Subtype> from being assigned to
+      // YDocument<Supertype>, requiring this cast.
+      const chatFactory = () => {
+        return YChat.create() as unknown as YDocument<DocumentChange>;
       };
       drive.sharedModelFactory.registerDocumentFactory('chat', chatFactory);
     }
@@ -358,7 +369,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
   id: pluginIds.chatCommands,
   description: 'The commands to create or open a chat.',
   autoStart: true,
-  requires: [ICollaborativeContentProvider, IChatFactory],
+  requires: [ICollaborativeContentProviderToken, IChatFactory],
   optional: [
     IActiveCellManagerToken,
     IChatPanel,
@@ -670,7 +681,11 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
   description: 'The chat panel widget.',
   autoStart: true,
   provides: IChatPanel,
-  requires: [IChatFactory, ICollaborativeContentProvider, IRenderMimeRegistry],
+  requires: [
+    IChatFactory,
+    ICollaborativeContentProviderToken,
+    IRenderMimeRegistry
+  ],
   optional: [
     IAttachmentOpenerRegistry,
     IChatCommandRegistry,
@@ -700,7 +715,6 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
      */
     const chatPanel = new ChatPanel({
       commands,
-      drive,
       contentsManager: app.serviceManager.contents,
       rmRegistry,
       themeManager,

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -20,10 +20,8 @@ import {
   chatIcon,
   readIcon
 } from '@jupyter/chat';
-import {
-  ICollaborativeDrive,
-  SharedDocumentFactory
-} from '@jupyter/collaborative-drive';
+import { ICollaborativeContentProvider } from '@jupyter/collaborative-drive';
+import { SharedDocumentFactory } from '@jupyterlab/services';
 import {
   ILayoutRestorer,
   JupyterFrontEnd,
@@ -113,7 +111,7 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
     IActiveCellManagerToken,
     IAttachmentOpenerRegistry,
     IChatCommandRegistry,
-    ICollaborativeDrive,
+    ICollaborativeContentProvider,
     IDefaultFileBrowser,
     IInputToolbarRegistryFactory,
     ILayoutRestorer,
@@ -131,7 +129,7 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
     activeCellManager: IActiveCellManager | null,
     attachmentOpenerRegistry: IAttachmentOpenerRegistry,
     chatCommandRegistry: IChatCommandRegistry,
-    drive: ICollaborativeDrive | null,
+    drive: ICollaborativeContentProvider | null,
     filebrowser: IDefaultFileBrowser | null,
     inputToolbarFactory: IInputToolbarRegistryFactory,
     restorer: ILayoutRestorer | null,
@@ -172,11 +170,11 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
         previousDirectory &&
         previousDirectory !== currentDirectory
       ) {
-        drive
+        app.serviceManager.contents
           .get(previousDirectory)
           .then(contentModel => {
             if (contentModel.content.length === 0) {
-              drive.delete(previousDirectory).catch(e => {
+              app.serviceManager.contents.delete(previousDirectory).catch(e => {
                 // no-op, the directory might not be empty
               });
             }
@@ -191,18 +189,18 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
         Promise.resolve(null);
 
       if (drive && currentDirectory && previousDirectory !== currentDirectory) {
-        directoryCreation = drive
+        directoryCreation = app.serviceManager.contents
           .get(currentDirectory, { content: false })
           .catch(async () => {
-            return drive
+            return app.serviceManager.contents
               .newUntitled({
                 type: 'directory'
               })
               .then(async contentModel => {
-                return drive
+                return app.serviceManager.contents
                   .rename(contentModel.path, currentDirectory)
                   .catch(e => {
-                    drive.delete(contentModel.path);
+                    app.serviceManager.contents.delete(contentModel.path);
                     throw new Error(e);
                   });
               })
@@ -360,7 +358,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
   id: pluginIds.chatCommands,
   description: 'The commands to create or open a chat.',
   autoStart: true,
-  requires: [ICollaborativeDrive, IChatFactory],
+  requires: [ICollaborativeContentProvider, IChatFactory],
   optional: [
     IActiveCellManagerToken,
     IChatPanel,
@@ -371,7 +369,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
   ],
   activate: (
     app: JupyterFrontEnd,
-    drive: ICollaborativeDrive,
+    drive: ICollaborativeContentProvider,
     factory: IChatFactory,
     activeCellManager: IActiveCellManager | null,
     chatPanel: ChatPanel | null,
@@ -430,9 +428,11 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
 
         let fileExist = true;
         if (filepath) {
-          await drive.get(filepath, { content: false }).catch(() => {
-            fileExist = false;
-          });
+          await app.serviceManager.contents
+            .get(filepath, { content: false })
+            .catch(() => {
+              fileExist = false;
+            });
         } else {
           fileExist = false;
         }
@@ -440,13 +440,17 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
         // Create a new file if it does not exists
         if (!fileExist) {
           // Create a new untitled chat.
-          let model: Contents.IModel | null = await drive.newUntitled({
-            type: 'file',
-            ext: chatFileType.extensions[0]
-          });
+          let model: Contents.IModel | null =
+            await app.serviceManager.contents.newUntitled({
+              type: 'file',
+              ext: chatFileType.extensions[0]
+            });
           // Rename it if a name has been provided.
           if (filepath) {
-            model = await drive.rename(model.path, filepath);
+            model = await app.serviceManager.contents.rename(
+              model.path,
+              filepath
+            );
           }
 
           if (!model) {
@@ -549,9 +553,11 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
             }
 
             let fileExist = true;
-            await drive.get(filepath, { content: false }).catch(() => {
-              fileExist = false;
-            });
+            await app.serviceManager.contents
+              .get(filepath, { content: false })
+              .catch(() => {
+                fileExist = false;
+              });
 
             if (!fileExist) {
               showErrorMessage(
@@ -585,7 +591,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
                 return;
               }
 
-              const model = await drive.get(filepath);
+              const model = await app.serviceManager.contents.get(filepath);
 
               // Create a share model from the chat file
               const sharedModel = drive.sharedModelFactory.createNew({
@@ -664,7 +670,7 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
   description: 'The chat panel widget.',
   autoStart: true,
   provides: IChatPanel,
-  requires: [IChatFactory, ICollaborativeDrive, IRenderMimeRegistry],
+  requires: [IChatFactory, ICollaborativeContentProvider, IRenderMimeRegistry],
   optional: [
     IAttachmentOpenerRegistry,
     IChatCommandRegistry,
@@ -676,7 +682,7 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
   activate: (
     app: JupyterFrontEnd,
     factory: IChatFactory,
-    drive: ICollaborativeDrive,
+    drive: ICollaborativeContentProvider,
     rmRegistry: IRenderMimeRegistry,
     attachmentOpenerRegistry: IAttachmentOpenerRegistry,
     chatCommandRegistry: IChatCommandRegistry,
@@ -695,6 +701,7 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
     const chatPanel = new ChatPanel({
       commands,
       drive,
+      contentsManager: app.serviceManager.contents,
       rmRegistry,
       themeManager,
       defaultDirectory,

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -70,10 +70,12 @@ import { DocumentChange, YDocument } from '@jupyter/ydoc';
 
 const FACTORY = 'Chat';
 
-// Cast ICollaborativeContentProvider token to Token<any> for JupyterLab compatibility.
-// Safe because different @lumino/coreutils versions create separate Token types with
-// private '_tokenStructuralPropertyT' properties. Tokens are just dependency injection
-// identifiers, the actual ICollaborativeContentProvider instance works correctly.
+// Cast ICollaborativeContentProvider token so TypeScript accepts it in plugin optional/requires arrays.
+// The arrays expect Token<any> from JupyterLab's @lumino/coreutils, but our token is from
+// @jupyter/collaborative-drive's @lumino/coreutils. These have separate Token class declarations
+// with their own private '_tokenStructuralPropertyT' properties, making TypeScript treat them as
+// distinct incompatible types even though they work identically. This is safe because tokens are just
+// dependency injection identifiers - the actual ICollaborativeContentProvider instance works correctly.
 const ICollaborativeContentProviderToken =
   ICollaborativeContentProvider as unknown as Token<any>;
 
@@ -272,10 +274,11 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
     app.docRegistry.addFileType(chatFileType);
 
     if (drive) {
-      // Cast YChat (YDocument<IChatChanges>) to YDocument<DocumentChange> for SharedDocumentFactory.
-      // Safe because IChatChanges extends DocumentChange, so YChat has all required functionality.
-      // TypeScript's generic invariance prevents YDocument<Subtype> from being assigned to
-      // YDocument<Supertype>, requiring this cast.
+      // Cast YChat return type to match SharedDocumentFactory's expected return type.
+      // SharedDocumentFactory expects YDocument<DocumentChange>, but YChat.create() returns
+      // YDocument<IChatChanges>. Since IChatChanges extends DocumentChange, the cast is valid.
+      // TypeScript's generic invariance requires the cast as YDocument<Subtype> isn't assignable
+      // to YDocument<Supertype> even when Subtype extends Supertype.
       const chatFactory = () => {
         return YChat.create() as unknown as YDocument<DocumentChange>;
       };

--- a/packages/jupyterlab-chat/package.json
+++ b/packages/jupyterlab-chat/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@jupyter/chat": "^0.11.0",
-    "@jupyter/collaborative-drive": "^3.0.0",
+    "@jupyter/collaborative-drive": "^4.0.2",
     "@jupyter/ydoc": "^2.0.0 || ^3.0.0",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.3.0",

--- a/packages/jupyterlab-chat/src/widget.tsx
+++ b/packages/jupyterlab-chat/src/widget.tsx
@@ -12,7 +12,7 @@ import {
   IMessageFooterRegistry,
   readIcon
 } from '@jupyter/chat';
-import { ICollaborativeDrive } from '@jupyter/collaborative-drive';
+import { Contents } from '@jupyterlab/services';
 import { IThemeManager } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 import { DocumentWidget } from '@jupyterlab/docregistry';
@@ -105,7 +105,7 @@ export class ChatPanel extends SidePanel {
     super(options);
     this.addClass(SIDEPANEL_CLASS);
     this._commands = options.commands;
-    this._drive = options.drive;
+    this._contentsManager = options.contentsManager;
     this._rmRegistry = options.rmRegistry;
     this._themeManager = options.themeManager;
     this._defaultDirectory = options.defaultDirectory;
@@ -203,9 +203,9 @@ export class ChatPanel extends SidePanel {
    */
   updateChatList = async (): Promise<void> => {
     const extension = chatFileType.extensions[0];
-    this._drive
+    this._contentsManager
       .get(this._defaultDirectory)
-      .then(contentModel => {
+      .then((contentModel: { content: any[] }) => {
         const chatsNames: { [name: string]: string } = {};
         (contentModel.content as any[])
           .filter(f => f.type === 'file' && f.name.endsWith(extension))
@@ -298,7 +298,7 @@ export class ChatPanel extends SidePanel {
   );
   private _commands: CommandRegistry;
   private _defaultDirectory: string;
-  private _drive: ICollaborativeDrive;
+  private _contentsManager: Contents.IManager;
   private _openChat: ReactWidget;
   private _rmRegistry: IRenderMimeRegistry;
   private _themeManager: IThemeManager | null;
@@ -317,7 +317,7 @@ export namespace ChatPanel {
    */
   export interface IOptions extends SidePanel.IOptions {
     commands: CommandRegistry;
-    drive: ICollaborativeDrive;
+    contentsManager: Contents.IManager;
     rmRegistry: IRenderMimeRegistry;
     themeManager: IThemeManager | null;
     defaultDirectory: string;

--- a/python/jupyterlab-chat/pyproject.toml
+++ b/python/jupyterlab-chat/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 ]
 dependencies = [
     "jupyterlab~=4.0",
-    "jupyter_collaboration>=3,<4",
+    "jupyter_server_documents==0.1.0a0",
     "jupyter_server>=2.0.1,<3",
-    "jupyter_ydoc",
-    "pycrdt"
+    "jupyter_ydoc>=3.0.0,<4.0.0",
+    "pycrdt>=0.12.0,<0.13.0"
 ]
 keywords = [
     "jupyter",

--- a/python/jupyterlab-chat/pyproject.toml
+++ b/python/jupyterlab-chat/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyterlab~=4.0",
-    "jupyter_server_documents==0.1.0a0",
+    "jupyter_server_documents>=0.1.0a0,<1.0.0",
     "jupyter_server>=2.0.1,<3",
     "jupyter_ydoc>=3.0.0,<4.0.0",
     "pycrdt>=0.12.0,<0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,15 +2534,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter/collaborative-drive@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@jupyter/collaborative-drive@npm:3.0.1"
+"@jupyter/collaborative-drive@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@jupyter/collaborative-drive@npm:4.0.2"
   dependencies:
-    "@jupyter/ydoc": ^2.0.0 || ^3.0.0
-    "@jupyterlab/services": ^7.2.0
-    "@lumino/coreutils": ^2.1.0
-    "@lumino/disposable": ^2.1.0
-  checksum: 14ef4bdd8b190495b0fdf5607e25d9dd990b8000ce46f78b4403d806fa95893701dec39fd52cd834ba969f1fbfca0672da09bb955def851f5e5d5b6a2704cdac
+    "@jupyter/ydoc": ^2.1.3 || ^3.0.0
+    "@jupyterlab/services": ^7.4.0
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+  checksum: 876b8f53d1dcad2a0aa875e5ce5337a53489ac248272ed7a7d907fa1457db52c7232c25ccc76422c24078db6d2e93dee816f7b21c22074f11e87a4d9601a47f5
   languageName: node
   linkType: hard
 
@@ -2594,6 +2594,20 @@ __metadata:
     y-protocols: ^1.0.5
     yjs: ^13.5.40
   checksum: f10268d4d990f454279e3908a172755ed5885fa81bb70c31bdf66923598b283d26491741bece137d1c348619861e9b7f8354296773fe5352b1915e69101a9fb0
+  languageName: node
+  linkType: hard
+
+"@jupyter/ydoc@npm:^2.1.3 || ^3.0.0, @jupyter/ydoc@npm:^3.0.4":
+  version: 3.0.5
+  resolution: "@jupyter/ydoc@npm:3.0.5"
+  dependencies:
+    "@jupyterlab/nbformat": ^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0
+    "@lumino/coreutils": ^1.11.0 || ^2.0.0
+    "@lumino/disposable": ^1.10.0 || ^2.0.0
+    "@lumino/signaling": ^1.10.0 || ^2.0.0
+    y-protocols: ^1.0.5
+    yjs: ^13.5.40
+  checksum: a4f8074790e34b649e581e093806ec84ccfdcd676735d35efdba74e93114c5ff3d40e5909322ce7fc7acd0faf379ecfb8979ab88af1db9705d74b0eff4e1c75c
   languageName: node
   linkType: hard
 
@@ -2839,6 +2853,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/coreutils@npm:^6.4.3":
+  version: 6.4.3
+  resolution: "@jupyterlab/coreutils@npm:6.4.3"
+  dependencies:
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+    minimist: ~1.2.0
+    path-browserify: ^1.0.0
+    url-parse: ~1.5.4
+  checksum: f9ffd692d4e30f4813e4985972ff4323752dd30497877b58a8a791f71eda8655efe2297c38cb83b6b0ed057707c8bf50633d7bdd9c2d388a400d986458307cf4
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/coreutils@npm:~6.2.0":
   version: 6.2.6
   resolution: "@jupyterlab/coreutils@npm:6.2.6"
@@ -3027,6 +3055,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/nbformat@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "@jupyterlab/nbformat@npm:4.4.3"
+  dependencies:
+    "@lumino/coreutils": ^2.2.1
+  checksum: 2e743fcf41fa7e0bbbe06fb417467b32b3679544f5b6ebf33623ce92e04e0d545c879e5eead6b201a83e2d8aa503df9c95050be67244cc4a6c65355120f9b0fe
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/notebook@npm:^4.2.0":
   version: 4.2.3
   resolution: "@jupyterlab/notebook@npm:4.2.3"
@@ -3159,6 +3196,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/services@npm:^7.4.0":
+  version: 7.4.3
+  resolution: "@jupyterlab/services@npm:7.4.3"
+  dependencies:
+    "@jupyter/ydoc": ^3.0.4
+    "@jupyterlab/coreutils": ^6.4.3
+    "@jupyterlab/nbformat": ^4.4.3
+    "@jupyterlab/settingregistry": ^4.4.3
+    "@jupyterlab/statedb": ^4.4.3
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/polling": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    ws: ^8.11.0
+  checksum: 83c3e903c54e665e73d5beec7bf0de8785a124974eefce13b146fcd9afa5f353e5a379097d7913d87f92800097f95e104ce224061bd113776092d31bb07bd8b4
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/settingregistry@npm:^4.2.0, @jupyterlab/settingregistry@npm:^4.2.3":
   version: 4.2.3
   resolution: "@jupyterlab/settingregistry@npm:4.2.3"
@@ -3178,6 +3234,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/settingregistry@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "@jupyterlab/settingregistry@npm:4.4.3"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.4.3
+    "@jupyterlab/statedb": ^4.4.3
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+    "@rjsf/utils": ^5.13.4
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: d9a6a4d130d7e7190633d08bb9d28c8273aba967b350f6d55c6281f36cda8a3cd71942daee34b32f47b94b2a1cd215b3c434b9243af54c494be1b86c2eea39e9
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/statedb@npm:^4.2.3":
   version: 4.2.3
   resolution: "@jupyterlab/statedb@npm:4.2.3"
@@ -3188,6 +3263,19 @@ __metadata:
     "@lumino/properties": ^2.0.1
     "@lumino/signaling": ^2.1.2
   checksum: 6969e54fa8370a918a4d78391116b83bd3c5afb25e1f66d7369ac2d24659b89a32bbb23500d81b50744698c504a47bd8bc355b16e4ec6ea877b74ec512aab3f8
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "@jupyterlab/statedb@npm:4.4.3"
+  dependencies:
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/properties": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+  checksum: ae50806cac848c752f4ecda6906d6566c626f28739a276438445a87a3f8a206ce920623486c499f433ae57d818a98e815b89bda34479c9d4bbfef86c784ad8b0
   languageName: node
   linkType: hard
 
@@ -3562,6 +3650,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/algorithm@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@lumino/algorithm@npm:2.0.3"
+  checksum: 03932cdc39d612a00579ee40bafb0b1d8bf5f8a12449f777a1ae7201843ddefb557bc3f9260aa6b9441d87bfc43e53cced854e71c4737de59e32cd00d4ac1394
+  languageName: node
+  linkType: hard
+
 "@lumino/application@npm:^2.3.1":
   version: 2.4.0
   resolution: "@lumino/application@npm:2.4.0"
@@ -3597,7 +3692,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.1.2, @lumino/coreutils@npm:^2.0.0, @lumino/coreutils@npm:^2.1.0, @lumino/coreutils@npm:^2.1.2, @lumino/coreutils@npm:^2.2.0":
+"@lumino/commands@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "@lumino/commands@npm:2.3.2"
+  dependencies:
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/domutils": ^2.0.3
+    "@lumino/keyboard": ^2.0.3
+    "@lumino/signaling": ^2.1.4
+    "@lumino/virtualdom": ^2.0.3
+  checksum: 090454bcc07aeb71f0791d6ca86ca4857b16bb6286a47ab6e59c3046e7f99cd3ef27c36d2dd35de7cf2bdeeaf5fc00ae8f29246a39e276eac2d186ae3cd7023e
+  languageName: node
+  linkType: hard
+
+"@lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.1.2, @lumino/coreutils@npm:^2.0.0, @lumino/coreutils@npm:^2.1.2, @lumino/coreutils@npm:^2.2.0":
   version: 2.2.0
   resolution: "@lumino/coreutils@npm:2.2.0"
   dependencies:
@@ -3606,7 +3716,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/disposable@npm:^1.10.0 || ^2.0.0, @lumino/disposable@npm:^2.0.0, @lumino/disposable@npm:^2.1.0, @lumino/disposable@npm:^2.1.2, @lumino/disposable@npm:^2.1.3":
+"@lumino/coreutils@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@lumino/coreutils@npm:2.2.1"
+  dependencies:
+    "@lumino/algorithm": ^2.0.3
+  checksum: d08570d1ebcf6bca973ba3af0836fb19a5a7a5b24979e90aab0fb4acb245e9619a0db356a78d67f618ae565435bb2aaf7c158c5bc0ae1ef9e9f1638ebfa05484
+  languageName: node
+  linkType: hard
+
+"@lumino/disposable@npm:^1.10.0 || ^2.0.0, @lumino/disposable@npm:^2.0.0, @lumino/disposable@npm:^2.1.2, @lumino/disposable@npm:^2.1.3":
   version: 2.1.3
   resolution: "@lumino/disposable@npm:2.1.3"
   dependencies:
@@ -3615,10 +3734,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/disposable@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@lumino/disposable@npm:2.1.4"
+  dependencies:
+    "@lumino/signaling": ^2.1.4
+  checksum: 0274c1cd81683f0d37c79795ed683fe49929452e6f075b9027b62dee376b5c6aa5f27b279236c4e1621bcbdcb844d5be0bbde3a065ab39159deb995244d1d2a7
+  languageName: node
+  linkType: hard
+
 "@lumino/domutils@npm:^2.0.1, @lumino/domutils@npm:^2.0.2":
   version: 2.0.2
   resolution: "@lumino/domutils@npm:2.0.2"
   checksum: 037b8d0b62af43887fd7edd506fa551e2af104a4b46d62e6fef256e16754dba40d351513beb5083834d468b2c7806aae0fe205fd6aac8ef24759451ee998bbd9
+  languageName: node
+  linkType: hard
+
+"@lumino/domutils@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@lumino/domutils@npm:2.0.3"
+  checksum: 46cbcbd38f6abb53eab1b6de0a2ea8a9fa5e28b0f5aa4b058c35f2380cb8ec881fe7616c7468ba200b785f95357ac8cbac6b64512f9945f5973d1d425864b163
   languageName: node
   linkType: hard
 
@@ -3636,6 +3771,13 @@ __metadata:
   version: 2.0.2
   resolution: "@lumino/keyboard@npm:2.0.2"
   checksum: 198e8c17825c9a831fa0770f58a71574b936acb0f0bbbe7f8feb73d89686dda7ff41fcb02d12b401f5d462b45fe0bba24f7f38befb7cefe0826576559f0bee6d
+  languageName: node
+  linkType: hard
+
+"@lumino/keyboard@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@lumino/keyboard@npm:2.0.3"
+  checksum: ca648cf978ddcf15fe3af2b8c8beb8aff153dfe616099df5a8bc7f43124420f77c358dbd33a988911b82f68debe07268d630c1777618b182ef7b520962d653e7
   languageName: node
   linkType: hard
 
@@ -3660,10 +3802,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/polling@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@lumino/polling@npm:2.1.4"
+  dependencies:
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+  checksum: e08d07d11eb030fed83bea232dba91af4ea40ef8f6ec7b8fe61722ebbd29faba10c67d269596c19c515c920f607c73bb64cdc9319af9ecef4619cddfd92ea764
+  languageName: node
+  linkType: hard
+
 "@lumino/properties@npm:^2.0.1, @lumino/properties@npm:^2.0.2":
   version: 2.0.2
   resolution: "@lumino/properties@npm:2.0.2"
   checksum: cbe802bd49ced7e13e50b1d89b82e0f03fb44a590c704e6b9343226498b21d8abfe119b024209e79876b4fc0938dbf85e964c6c4cd5bbdd4d7ba41ce0fb69f3f
+  languageName: node
+  linkType: hard
+
+"@lumino/properties@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@lumino/properties@npm:2.0.3"
+  checksum: a575d821f994090907abb567d3af21a828f528ae5f329ada92719eba9818bbb2b0955e675b91bd392043a5d835c345d7b500994a77157c5ea317f36442ce570e
   languageName: node
   linkType: hard
 
@@ -3677,12 +3837,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/signaling@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@lumino/signaling@npm:2.1.4"
+  dependencies:
+    "@lumino/algorithm": ^2.0.3
+    "@lumino/coreutils": ^2.2.1
+  checksum: 554a5135c8742ed3f61a4923b1f26cb29b55447ca5939df70033449cfb654a37048d7a3e2fd0932497099cd24501a3819b85cd1fdf4e76023ba0af747c171d53
+  languageName: node
+  linkType: hard
+
 "@lumino/virtualdom@npm:^2.0.1, @lumino/virtualdom@npm:^2.0.2":
   version: 2.0.2
   resolution: "@lumino/virtualdom@npm:2.0.2"
   dependencies:
     "@lumino/algorithm": ^2.0.2
   checksum: 0e1220d5b3b2441e7668f3542a6341e015bdbea0c8bd6d4be962009386c034336540732596d5dedcd54ca57fbde61c2942549129a3e1b0fccb1aa143685fcd15
+  languageName: node
+  linkType: hard
+
+"@lumino/virtualdom@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@lumino/virtualdom@npm:2.0.3"
+  dependencies:
+    "@lumino/algorithm": ^2.0.3
+  checksum: 66c18494fdfc1b87e76286140cd256b3616aede262641912646a18395226e200048ddeaa6d1644dff3f597b1cde8e583968cb973d64a9e9d4f45e2b24c1e2c7c
   languageName: node
   linkType: hard
 
@@ -10105,8 +10284,8 @@ __metadata:
   resolution: "jupyterlab-chat-extension@workspace:packages/jupyterlab-chat-extension"
   dependencies:
     "@jupyter-notebook/application": ^7.2.0
-    "@jupyter/collaborative-drive": ^3.0.0
-    "@jupyter/ydoc": ^2.0.0 || ^3.0.0
+    "@jupyter/collaborative-drive": ^4.0.2
+    "@jupyter/ydoc": ^2.1.3 || ^3.0.0
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.3.0
     "@jupyterlab/builder": ^4.2.0
@@ -10146,7 +10325,7 @@ __metadata:
   resolution: "jupyterlab-chat@workspace:packages/jupyterlab-chat"
   dependencies:
     "@jupyter/chat": ^0.11.0
-    "@jupyter/collaborative-drive": ^3.0.0
+    "@jupyter/collaborative-drive": ^4.0.2
     "@jupyter/ydoc": ^2.0.0 || ^3.0.0
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2597,7 +2597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/ydoc@npm:^2.1.3 || ^3.0.0, @jupyter/ydoc@npm:^3.0.4":
+"@jupyter/ydoc@npm:^2.1.3 || ^3.0.0, @jupyter/ydoc@npm:^3.0.0, @jupyter/ydoc@npm:^3.0.4":
   version: 3.0.5
   resolution: "@jupyter/ydoc@npm:3.0.5"
   dependencies:
@@ -10285,7 +10285,7 @@ __metadata:
   dependencies:
     "@jupyter-notebook/application": ^7.2.0
     "@jupyter/collaborative-drive": ^4.0.2
-    "@jupyter/ydoc": ^2.1.3 || ^3.0.0
+    "@jupyter/ydoc": ^3.0.0
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.3.0
     "@jupyterlab/builder": ^4.2.0
@@ -10295,7 +10295,7 @@ __metadata:
     "@jupyterlab/launcher": ^4.2.0
     "@jupyterlab/notebook": ^4.2.0
     "@jupyterlab/rendermime": ^4.2.0
-    "@jupyterlab/services": ^7.2.0
+    "@jupyterlab/services": ^7.4.0
     "@jupyterlab/settingregistry": ^4.2.0
     "@jupyterlab/translation": ^4.2.0
     "@jupyterlab/ui-components": ^4.2.0


### PR DESCRIPTION
### Description 
Updates `jupyter-chat` to use `jupyter_server_documents` instead of `jupyter-collaboration`.

* Updates `jupyter-chat` to work with `@jupyter/collaborative-drive` v4 (from v3)
* Migrates from `ICollaborativeDrive` to `ICollaborativeContentProvider` following the new content provider architecture
* Updates file operations to use `app.serviceManager.contents` instead of drive methods
* Removes unused `drive` property from `ChatPanel` in favor of `contentsManager`
* Adds necessary type casts for cross-package compatibility between Token and YDocument types

### Testing 

1. Install the extension accordingly to the [docs](https://jupyter-chat.readthedocs.io/en/latest/developers/contributing/jupyterlab-chat-extension.html#development-installation)
```
$ python ./scripts/dev_install.py
```
2. Run unit tests
```
$ cd ./python/jupyterlab-chat
$ jlpm test
```